### PR TITLE
Add support for reading config from LightwaveRF Gem config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # homebridge-lightwaverf
+
 LightWaveRF plugin for homebridge: https://github.com/nfarina/homebridge
-Note: This plugin communicates with the KlikAanKlikUit ICS-1000 or Lightwave Link
-Set the correct manager_host in the configuration:
+
+Note: This plugin reads configuration from the KlikAanKlikUit ICS-1000, Lightwave Link or LightwaveRF Gem YAML file.
+
+Set the correct `manager_host` or the `file` property in the configuration:
 - web.trustsmartcloud.com
 - lightwaverfhost.co.uk
 
 # Installation
 
-1. Install homebridge using: npm install -g homebridge
-2. Install this plugin using: npm install -g homebridge-lightwaverf
+1. Install homebridge using: `npm install -g homebridge`
+2. Install this plugin using: `npm install -g homebridge-lightwaverf`
 3. Update your configuration file. See the sample below.
 
 # Configuration
@@ -26,6 +29,17 @@ Configuration sample:
           "pin: "1234"
         }   
     ]
-
 ```
 
+Or, for a local LightwaveRF Gem YAML configuration:
+
+```
+"platforms": [
+        {
+          "platform": "LightWaveRF",
+          "name": "LightWaveRF",
+          "ip_address": "192.168.1.123",
+          "file": "/a/config/file.yml"
+        }
+    ]
+```

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ function LightWaveRFPlatform(log, config) {
   this.email = config["email"];
   this.pin = config["pin"];
   this.host = "web.trustsmartcloud.com";
+  this.file = config['file'];
   if(config["manager_host"]) this.host = config["manager_host"];
   
   this.log("LightWaveRF Platform Plugin Version " + this.getVersion());
@@ -75,21 +76,25 @@ LightWaveRFPlatform.prototype = {
     this.log("Fetching LightWaveRF switches and dimmers...");
     var that = this;
     var getLights = function () {
+      var lightwaveConfig;
+      if (that.file) {
+        lightwaveConfig = {ip:that.ip_address, file:that.file};
+
+      } else {
+        if(!that.email) {
+            // Get email
+            var prompt = require('prompt');
+            prompt.start();
+            prompt.get(['email', 'pin'], function (err, result) {
+              if (err) { return this.onErr(err); }
+              console.log('Command-line input received:');
+              that.email = result.email;
+              that.pin = result.pin;
+              //console.log('  Email: ' + result.email);
+              //console.log('  Pin: ' + result.pin);
+              });
+        }
         
-      if(!that.email) {
-          // Get email
-          var prompt = require('prompt');
-          prompt.start();
-          prompt.get(['email', 'pin'], function (err, result) {
-            if (err) { return this.onErr(err); }
-            console.log('Command-line input received:');
-            that.email = result.email;
-            that.pin = result.pin;
-            //console.log('  Email: ' + result.email);
-            //console.log('  Pin: ' + result.pin);
-            });
-      }
-      
         if(!that.pin) {
             // Get email
             var prompt = require('prompt');
@@ -101,17 +106,18 @@ LightWaveRFPlatform.prototype = {
                        //console.log('  Pin: ' + result.pin);
                        });
         }
-        
-        var api = new lightwaverf({ip:that.ip_address,email:that.email,pin:that.pin,host:that.host}, function(devices) {
-      
-            var foundAccessories = [];
-            for(var i=0;i<devices.length;++i) {
-                var device = api.devices[i];
-                var accessory = new LightWaveRFAccessory(that.log, device, api);
-                foundAccessories.push(accessory);
-            }
-            callback(foundAccessories);
-        });
+
+        lightwaveConfig = {ip:that.ip_address,email:that.email,pin:that.pin,host:that.host};
+      }
+
+      new lightwaverf(lightwaveConfig, function(devices, api) {
+          var foundAccessories = [];
+          for(var i=0;i<devices.length;++i) {
+              var accessory = new LightWaveRFAccessory(that.log, devices[i], api);
+              foundAccessories.push(accessory);
+          }
+          callback(foundAccessories);
+      });
 
     };
       


### PR DESCRIPTION
These are the downstream changes to support https://github.com/rooi/node-lightwaverf/pull/1 in the _homebridge_ plugin - it merely adds support to point the _node-lightwaverf_ module at a given configuration file. Exciting stuff :smile: 

Many thanks again for your work on this!
