### PR TITLE
fix typos

### DIFF
--- a/lib/lightwaverf.js
+++ b/lib/lightwaverf.js
@@ -329,8 +329,8 @@ LightwaveRF.prototype.sendUdp = function(rd, cmd, callback){
 	//Add listener
 	if (callback) {
         if(Object.keys(this.responseListeners).length > 1) {
-            this.log.warn("LightWaveRF does not seem to receive responce from the link.");
-            this.log.warn("Please check the link's IP address in the configuration AND if homebridge is registered on the link by viewing its screen after issuing a homkit command");
+            this.log.warn("LightWaveRF does not seem to receive response from the link.");
+            this.log.warn("Please check the link's IP address in the configuration AND if homebridge is registered on the link by viewing its screen after issuing a homekit command");
         }
         
         this.responseListeners[parseInt(code, 10).toString()] = {


### PR DESCRIPTION
Just fixes two small typos in the error message when the link is not paired.